### PR TITLE
NewsItemActionState, EditionAction state entity

### DIFF
--- a/modules/converge-core/src/main/java/dk/i2m/converge/core/content/NewsItemActionState.java
+++ b/modules/converge-core/src/main/java/dk/i2m/converge/core/content/NewsItemActionState.java
@@ -1,0 +1,165 @@
+package dk.i2m.converge.core.content;
+
+import dk.i2m.converge.core.plugin.EditionAction;
+import dk.i2m.converge.core.workflow.Edition;
+
+import javax.persistence.*;
+import java.io.Serializable;
+
+/**
+ * Tracking data of a {@link NewsItem} in an {@link EditionAction}.
+ *
+ * @author Raymond Wanyoike
+ */
+@Entity
+@Table(name = "news_item_action_state")
+@NamedQueries({
+        @NamedQuery(name = NewsItemActionState.FIND_BY_EDITION_NEWSITEM_ACTION, query = "SELECT n FROM NewsItemActionState AS n WHERE n.edition.id = :" + NewsItemActionState.PARAM_EDITION_ID + " AND n.newsItem.id = :" + NewsItemActionState.PARAM_NEWS_ITEM_ID + " AND n.action = :" + NewsItemActionState.PARAM_ACTION),
+        @NamedQuery(name = NewsItemActionState.FIND_BY_EDITION_NEWSITEM, query = "SELECT n FROM NewsItemActionState AS n WHERE n.edition.id = :" + NewsItemActionState.PARAM_EDITION_ID + " AND n.newsItem.id = :" + NewsItemActionState.PARAM_NEWS_ITEM_ID),
+        @NamedQuery(name = NewsItemActionState.FIND_BY_EDITION, query = "SELECT n FROM NewsItemActionState AS n WHERE n.edition.id = :" + NewsItemActionState.PARAM_EDITION_ID),
+        @NamedQuery(name = NewsItemActionState.DELETE_BY_EDITION_NEWSITEM, query = "DELETE FROM NewsItemActionState AS n WHERE n.edition.id = :" + NewsItemActionState.PARAM_EDITION_ID + " AND n.newsItem.id = :" + NewsItemActionState.PARAM_NEWS_ITEM_ID),
+        @NamedQuery(name = NewsItemActionState.DELETE_BY_EDITION, query = "DELETE FROM NewsItemActionState AS n WHERE n.edition.id = :" + NewsItemActionState.PARAM_EDITION_ID)
+})
+public class NewsItemActionState implements Serializable {
+
+    /**
+     * Query for locating a {@link NewsItemActionState} based on the Edition, NewsItem and Property name using
+     * {@link NewsItemActionState.PARAM_EDITION_ID}, {@link NewsItemActionState.PARAM_NEWS_ITEM_ID} and
+     * {@link NewsItemActionState.PARAM_ACTION}.
+     */
+    public static final String FIND_BY_EDITION_NEWSITEM_ACTION = "NewsItemActionState.findByEditionNewsItemProperty";
+    /**
+     * Query for locating a {@link NewsItemActionState} based on the Edition, NewsItem using
+     * {@link NewsItemActionState.PARAM_EDITION_ID} and {@link NewsItemActionState.PARAM_NEWS_ITEM_ID}.
+     */
+    public static final String FIND_BY_EDITION_NEWSITEM = "NewsItemActionState.findByEditionNewsItem";
+    /**
+     * Query for locating a {@link NewsItemActionState} based on the Edition using
+     * {@link NewsItemActionState.PARAM_EDITION_ID}.
+     */
+    public static final String FIND_BY_EDITION = "NewsItemActionState.findByEdition";
+    /**
+     * Query for deleting {@link NewsItemActionState} based on the Edition, NewsItem using
+     * {@link NewsItemActionState.PARAM_EDITION_ID} and {@link NewsItemActionState.PARAM_NEWS_ITEM_ID}.
+     */
+    public static final String DELETE_BY_EDITION_NEWSITEM = "NewsItemActionState.deleteByEditionNewsItem";
+    /**
+     * Query for deleting {@link NewsItemActionState} based on the Edition using
+     * {@link NewsItemActionState.PARAM_EDITION_ID} and {@link NewsItemActionState.PARAM_NEWS_ITEM_ID}.
+     */
+    public static final String DELETE_BY_EDITION = "NewsItemActionState.deleteByEdition";
+    /**
+     * Query parameter for specifying the ID of an Edition.
+     */
+    public static final String PARAM_EDITION_ID = "editionId";
+    /**
+     * Query parameter for specifying the ID of a News Item.
+     */
+    public static final String PARAM_NEWS_ITEM_ID = "newsItemId";
+    /**
+     * Query parameter for specifying the ID of a Action.
+     */
+    public static final String PARAM_ACTION = "action";
+
+    @Id
+    @Column(name = "id")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "edition_id")
+    private Edition edition;
+
+    @ManyToOne
+    @JoinColumn(name = "news_item_id")
+    private NewsItem newsItem;
+
+    @Column(name = "edition_action")
+    private String action;
+
+    @Column(name = "state")
+    private String state;
+
+    @Column(name = "data")
+    private String data;
+
+    public NewsItemActionState() {
+    }
+
+    public NewsItemActionState(Edition edition, NewsItem newsItem, String action, String state, String data) {
+        this.edition = edition;
+        this.newsItem = newsItem;
+        this.action = action;
+        this.state = state;
+        this.data = data;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public Edition getEdition() {
+        return edition;
+    }
+
+    public void setEdition(Edition edition) {
+        this.edition = edition;
+    }
+
+    public NewsItem getNewsItem() {
+        return newsItem;
+    }
+
+    public void setNewsItem(NewsItem newsItem) {
+        this.newsItem = newsItem;
+    }
+
+    public String getAction() {
+        return action;
+    }
+
+    public void setAction(String action) {
+        this.action = action;
+    }
+
+    public String getState() {
+        return state;
+    }
+
+    public void setState(String state) {
+        this.state = state;
+    }
+
+    public String getData() {
+        return data;
+    }
+
+    public void setData(String data) {
+        this.data = data;
+    }
+
+    @Override
+    public int hashCode() {
+        int hash = 0;
+        hash += (id != null ? id.hashCode() : 0);
+        return hash;
+    }
+
+    @Override
+    public boolean equals(Object object) {
+        if (!(object instanceof NewsItemActionState)) {
+            return false;
+        }
+        NewsItemActionState other = (NewsItemActionState) object;
+        return !((this.id == null && other.id != null) || (this.id != null && !this.id.equals(other.id)));
+    }
+
+    @Override
+    public String toString() {
+        return getClass().getName() + "[ id=" + id + " ]";
+    }
+}

--- a/modules/converge-core/src/main/java/dk/i2m/converge/core/plugin/PluginContext.java
+++ b/modules/converge-core/src/main/java/dk/i2m/converge/core/plugin/PluginContext.java
@@ -21,6 +21,7 @@ import dk.i2m.converge.core.DataNotFoundException;
 import dk.i2m.converge.core.EnrichException;
 import dk.i2m.converge.core.Notification;
 import dk.i2m.converge.core.content.NewsItem;
+import dk.i2m.converge.core.content.NewsItemActionState;
 import dk.i2m.converge.core.content.NewsItemEditionState;
 import dk.i2m.converge.core.content.NewsItemPlacement;
 import dk.i2m.converge.core.content.catalogue.Catalogue;
@@ -37,6 +38,7 @@ import dk.i2m.converge.core.search.SearchEngineIndexingException;
 import dk.i2m.converge.core.security.UserAccount;
 import dk.i2m.converge.core.workflow.Edition;
 import dk.i2m.converge.core.workflow.Outlet;
+import dk.i2m.converge.core.workflow.OutletEditionAction;
 import dk.i2m.converge.core.workflow.WorkflowState;
 import dk.i2m.converge.core.workflow.WorkflowStateTransitionException;
 import java.util.List;
@@ -378,4 +380,51 @@ public interface PluginContext {
      * completed
      */
     void workflowTransition(Long newsItemId, String uid, long step) throws WorkflowStateTransitionException;
+
+    /**
+     * Create a new {@link NewsItemActionState} for a {@link NewsItem}.
+     *
+     * @param editionId {@link Edition} id the {@link NewsItem} belongs to
+     * @param newsItemId {@link NewsItem} id that will have a new state created
+     * @param action {@Edition} action (class name)
+     * @param data State
+     * @param data State data
+     * @return Created {@link NewsItemActionState}
+     */
+    NewsItemActionState addNewsItemActionState(Long editionId, Long newsItemId, String action, String state, String data);
+
+    /**
+     * Update an existing {@link NewsItemActionState}
+     *
+     * @param newsItemActionState {@link NewsItemActionState} to update
+     * @return Updated {@link NewsItemActionState}
+     */
+    NewsItemActionState updateNewsItemActionState(NewsItemActionState newsItemActionState);
+
+    /**
+     * Find an existing {@Link NewsItemActionState} based on the edition, news
+     * item, and action identifiers.
+     *
+     * @param editionId {@link Edition} id the {@link NewsItem} belongs to
+     * @param newsItemId {@link NewsItem} id that will have a new state created
+     * @param action {@Edition} action (class name)
+     * @return {@link NewsItemActionState} matching the given variables
+     * @throws DataNotFoundException If the {@link NewsItemActionState} could
+     * not be found
+     */
+    NewsItemActionState findNewsItemActionState(Long editionId, Long newsItemId, String action) throws DataNotFoundException;
+
+    /**
+     * Find an existing {@Link NewsItemActionState} based on the edition, news
+     * item, and action identifiers. If a {@link NewsItemActionState} can not
+     * be found, it is created in the database.
+     *
+     * @param editionId {@link Edition} id the {@link NewsItem} belongs to
+     * @param newsItemId {@link NewsItem} id that will have a new state created
+     * @param action {@Edition} action (class name)
+     * @param data State
+     * @param data State data
+     * @return {@link NewsItemActionState} matching the given variables
+     */
+    NewsItemActionState findNewsItemActionStateOrCreate(Long editionId, Long newsItemId, String action, String state, String data);
 }

--- a/modules/converge-ejb/src/main/java/dk/i2m/converge/ejb/facades/NewsItemFacadeBean.java
+++ b/modules/converge-ejb/src/main/java/dk/i2m/converge/ejb/facades/NewsItemFacadeBean.java
@@ -1190,6 +1190,81 @@ public class NewsItemFacadeBean implements NewsItemFacadeLocal {
         daoService.executeQuery(NewsItemEditionState.DELETE_BY_EDITION_NEWSITEM, criteria);
     }
 
+    @Override
+    public NewsItemActionState addNewsItemActionState(Long editionId, Long newsItemId, String action, String state, String data) {
+        try {
+            Edition edition = outletFacade.findEditionById(editionId);
+            NewsItem newsitem = findNewsItemById(newsItemId);
+            NewsItemActionState newsItemActionState = new NewsItemActionState(edition, newsitem, action, state, data);
+            return daoService.create(newsItemActionState);
+        } catch (DataNotFoundException ex) {
+            LOG.log(Level.SEVERE, ex.getMessage());
+            LOG.log(Level.FINEST, "", ex);
+        }
+        return new NewsItemActionState();
+    }
+
+    @Override
+    public NewsItemActionState updateNewsItemActionState(NewsItemActionState newsItemActionState) {
+        return daoService.update(newsItemActionState);
+    }
+
+    @Override
+    public NewsItemActionState findNewsItemActionState(Long editionId, Long newsItemId, String action) throws DataNotFoundException {
+        QueryBuilder criteria = QueryBuilder
+                .with(NewsItemActionState.PARAM_EDITION_ID, editionId)
+                .and(NewsItemActionState.PARAM_NEWS_ITEM_ID, newsItemId)
+                .and(NewsItemActionState.PARAM_ACTION, action);
+        return daoService.findObjectWithNamedQuery(NewsItemActionState.class, NewsItemActionState.FIND_BY_EDITION_NEWSITEM_ACTION, criteria.parameters());
+    }
+
+    @Override
+    public NewsItemActionState findNewsItemActionStateOrCreate(Long editionId, Long newsItemId, String action, String state, String data) {
+        LOG.log(Level.FINER, "Looking for NewsItemActionState. Edition: {0}, News Item: {1}, Action: {2}", new Object[]{editionId, newsItemId, action});
+        NewsItemActionState newsItemActionState;
+        try {
+            newsItemActionState = findNewsItemActionState(editionId, newsItemId, action);
+            LOG.log(Level.FINER, "NewsItemActionState found: {0}", newsItemActionState.getId());
+        } catch (DataNotFoundException ex) {
+            LOG.log(Level.FINER, "NewsItemActionState was not found. Creating new NewsItemActionState");
+            newsItemActionState = addNewsItemActionState(editionId, newsItemId, action, state, data);
+        }
+        return newsItemActionState;
+    }
+
+    @Override
+    public List<NewsItemActionState> findNewsItemActionStates(Long editionId) {
+        QueryBuilder criteria = QueryBuilder.with(NewsItemActionState.PARAM_EDITION_ID, editionId);
+        return daoService.findWithNamedQuery(NewsItemActionState.FIND_BY_EDITION, criteria.parameters());
+    }
+
+    @Override
+    public List<NewsItemActionState> findNewsItemActionStates(Long editionId, Long newsItemId) {
+        QueryBuilder criteria = QueryBuilder
+                .with(NewsItemActionState.PARAM_EDITION_ID, editionId)
+                .and(NewsItemActionState.PARAM_NEWS_ITEM_ID, newsItemId);
+        return daoService.findWithNamedQuery(NewsItemActionState.FIND_BY_EDITION_NEWSITEM, criteria.parameters());
+    }
+
+    @Override
+    public void clearNewsItemActionStateById(Long newsItemActionStateId) {
+        daoService.delete(NewsItemActionState.class, newsItemActionStateId);
+    }
+
+    @Override
+    public void clearNewsItemActionState(Long editionId) {
+        QueryBuilder criteria = QueryBuilder.with(NewsItemActionState.PARAM_EDITION_ID, editionId);
+        daoService.executeQuery(NewsItemActionState.DELETE_BY_EDITION, criteria);
+    }
+
+    @Override
+    public void clearNewsItemActionState(Long editionId, Long newsItemId) {
+        QueryBuilder criteria = QueryBuilder
+                .with(NewsItemActionState.PARAM_EDITION_ID, editionId)
+                .and(NewsItemActionState.PARAM_NEWS_ITEM_ID, newsItemId);
+        daoService.executeQuery(NewsItemActionState.DELETE_BY_EDITION_NEWSITEM, criteria);
+    }
+
     /**
      * Helper function for getting the current workflow user.
      *

--- a/modules/converge-ejb/src/main/java/dk/i2m/converge/ejb/facades/NewsItemFacadeBean.java
+++ b/modules/converge-ejb/src/main/java/dk/i2m/converge/ejb/facades/NewsItemFacadeBean.java
@@ -1211,6 +1211,7 @@ public class NewsItemFacadeBean implements NewsItemFacadeLocal {
 
     @Override
     public NewsItemActionState findNewsItemActionState(Long editionId, Long newsItemId, String action) throws DataNotFoundException {
+        LOG.log(Level.FINER, "Looking for NewsItemActionState. Edition: {0}, NewsItem: {1}, Action: {2}", new Object[]{editionId, newsItemId, action});
         QueryBuilder criteria = QueryBuilder
                 .with(NewsItemActionState.PARAM_EDITION_ID, editionId)
                 .and(NewsItemActionState.PARAM_NEWS_ITEM_ID, newsItemId)
@@ -1220,7 +1221,6 @@ public class NewsItemFacadeBean implements NewsItemFacadeLocal {
 
     @Override
     public NewsItemActionState findNewsItemActionStateOrCreate(Long editionId, Long newsItemId, String action, String state, String data) {
-        LOG.log(Level.FINER, "Looking for NewsItemActionState. Edition: {0}, News Item: {1}, Action: {2}", new Object[]{editionId, newsItemId, action});
         NewsItemActionState newsItemActionState;
         try {
             newsItemActionState = findNewsItemActionState(editionId, newsItemId, action);

--- a/modules/converge-ejb/src/main/java/dk/i2m/converge/ejb/facades/NewsItemFacadeLocal.java
+++ b/modules/converge-ejb/src/main/java/dk/i2m/converge/ejb/facades/NewsItemFacadeLocal.java
@@ -17,16 +17,17 @@
  */
 package dk.i2m.converge.ejb.facades;
 
+import dk.i2m.converge.core.content.ContentItemPermission;
+import dk.i2m.converge.core.content.NewsItem;
+import dk.i2m.converge.core.content.NewsItemActionState;
+import dk.i2m.converge.core.content.NewsItemEditionState;
+import dk.i2m.converge.core.content.NewsItemMediaAttachment;
+import dk.i2m.converge.core.content.NewsItemPlacement;
 import dk.i2m.converge.core.workflow.WorkflowStateTransitionException;
 import dk.i2m.converge.core.content.catalogue.MediaItem;
 import dk.i2m.converge.core.views.CurrentAssignment;
 import dk.i2m.converge.core.DataNotFoundException;
 import dk.i2m.converge.core.workflow.Outlet;
-import dk.i2m.converge.core.content.ContentItemPermission;
-import dk.i2m.converge.core.content.NewsItem;
-import dk.i2m.converge.core.content.NewsItemEditionState;
-import dk.i2m.converge.core.content.NewsItemMediaAttachment;
-import dk.i2m.converge.core.content.NewsItemPlacement;
 import dk.i2m.converge.core.workflow.WorkflowState;
 import dk.i2m.converge.core.security.UserAccount;
 import dk.i2m.converge.core.views.InboxView;
@@ -326,4 +327,22 @@ public interface NewsItemFacadeLocal {
     void clearNewsItemEditionState(Long editionId);
 
     void clearNewsItemEditionState(Long editionId, Long newsItemId);
+
+    NewsItemActionState addNewsItemActionState(Long editionId, Long newsItemId, String action, String state, String data);
+
+    NewsItemActionState updateNewsItemActionState(NewsItemActionState newsItemActionState);
+
+    NewsItemActionState findNewsItemActionState(Long editionId, Long newsItemId, String action) throws DataNotFoundException;
+
+    NewsItemActionState findNewsItemActionStateOrCreate(Long editionId, Long newsItemId, String action, String state, String data);
+
+    List<NewsItemActionState> findNewsItemActionStates(Long editionId);
+
+    List<NewsItemActionState> findNewsItemActionStates(Long editionId, Long newsItemId);
+
+    void clearNewsItemActionStateById(Long newsItemActionStateId);
+
+    void clearNewsItemActionState(Long editionId);
+
+    void clearNewsItemActionState(Long editionId, Long newsItemId);
 }

--- a/modules/converge-ejb/src/main/java/dk/i2m/converge/ejb/services/PluginContextBean.java
+++ b/modules/converge-ejb/src/main/java/dk/i2m/converge/ejb/services/PluginContextBean.java
@@ -23,6 +23,7 @@ import dk.i2m.converge.core.EnrichException;
 import dk.i2m.converge.core.Notification;
 import dk.i2m.converge.core.content.ContentTag;
 import dk.i2m.converge.core.content.NewsItem;
+import dk.i2m.converge.core.content.NewsItemActionState;
 import dk.i2m.converge.core.content.NewsItemEditionState;
 import dk.i2m.converge.core.content.NewsItemPlacement;
 import dk.i2m.converge.core.content.catalogue.Catalogue;
@@ -365,5 +366,25 @@ public class PluginContextBean implements PluginContextBeanLocal {
         } catch (DirectoryException ex) {
             throw new WorkflowStateTransitionException(ex);
         }
+    }
+
+    @Override
+    public NewsItemActionState addNewsItemActionState(Long editionId, Long newsItemId, String action, String state, String data) {
+        return newsItemFacade.addNewsItemActionState(editionId, newsItemId, action, state, data);
+    }
+
+    @Override
+    public NewsItemActionState updateNewsItemActionState(NewsItemActionState newsItemActionState) {
+        return newsItemFacade.updateNewsItemActionState(newsItemActionState);
+    }
+
+    @Override
+    public NewsItemActionState findNewsItemActionState(Long editionId, Long newsItemId, String action) throws DataNotFoundException {
+        return newsItemFacade.findNewsItemActionState(editionId, newsItemId, action);
+    }
+
+    @Override
+    public NewsItemActionState findNewsItemActionStateOrCreate(Long editionId, Long newsItemId, String action, String state, String data) {
+        return newsItemFacade.findNewsItemActionStateOrCreate(editionId, newsItemId, action, state, data);
     }
 }

--- a/modules/converge-war/src/main/java/dk/i2m/converge/jsf/beans/Planning.java
+++ b/modules/converge-war/src/main/java/dk/i2m/converge/jsf/beans/Planning.java
@@ -1,22 +1,23 @@
 /*
  *  Copyright (C) 2010 - 2012 Interactive Media Management
  *  Copyright (C) 2014 Allan Lykke Christensen
- * 
+ *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
  *  the Free Software Foundation, either version 3 of the License, or
  *  (at your option) any later version.
- * 
+ *
  *  This program is distributed in the hope that it will be useful,
  *  but WITHOUT ANY WARRANTY; without even the implied warranty of
  *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  *  GNU General Public License for more details.
- * 
+ *
  *  You should have received a copy of the GNU General Public License
  *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 package dk.i2m.converge.jsf.beans;
 
+import dk.i2m.converge.core.content.NewsItemActionState;
 import dk.i2m.converge.core.workflow.WorkflowStateTransitionException;
 import dk.i2m.converge.core.DataNotFoundException;
 import dk.i2m.converge.core.annotations.OutletAction;
@@ -118,8 +119,10 @@ public class Planning implements UIEventListener {
 
     private DataModel editionLogEntries = new ListDataModel();
     private DataModel editionStates = new ListDataModel();
+    private DataModel actionStates = new ListDataModel();
     private DataModel logEntries = new ListDataModel();
     private DataModel newsItemEditionStates = new ListDataModel();
+    private DataModel newsItemActionStates = new ListDataModel();
 
     private final ResourceBundle bundle = JsfUtils.getResourceBundle(Bundle.i18n.name());
 
@@ -537,7 +540,7 @@ public class Planning implements UIEventListener {
         newsItemFacade.updatePlacement(assignment.getPlacementId(), assignment.
                 getStart(), assignment.getPosition());
     }
-    
+
     public void onRefreshEditionPlacements(ActionEvent event) {
         fetchEditions();
     }
@@ -852,6 +855,7 @@ public class Planning implements UIEventListener {
         this.selectedEditionView = selectedEditionView;
         onRefreshEditionLogEntries(null);
         onRefreshEditionStates(null);
+        onRefreshActionStates(null);
     }
 
     public List<OutletActionView> getSelectedOutletActions() {
@@ -889,6 +893,7 @@ public class Planning implements UIEventListener {
 
             onRefreshNewsItemLogEntries(null);
             onRefreshNewsItemEditionState(null);
+            onRefreshNewsItemActionState(null);
         } catch (DataNotFoundException ex) {
             JsfUtils.createMessage("frmPage", FacesMessage.SEVERITY_ERROR,
                     Bundle.i18n.name(), "Editions_NEWS_ITEM_COULD_NOT_BE_FOUND");
@@ -960,5 +965,40 @@ public class Planning implements UIEventListener {
         Long editionId = getSelectedEditionView().getId();
         newsItemFacade.clearNewsItemEditionState(editionId);
         onRefreshEditionStates(event);
+    }
+
+    public DataModel getActionStates() {
+        return this.actionStates;
+    }
+
+    public void onRefreshActionStates(ActionEvent event) {
+        Long editionId = getSelectedEditionView().getId();
+        List<NewsItemActionState> properties = newsItemFacade.findNewsItemActionStates(editionId);
+        this.actionStates = new ListDataModel(properties);
+    }
+
+    public DataModel getNewsItemActionStates() {
+        return this.newsItemActionStates;
+    }
+
+    public void onRefreshNewsItemActionState(ActionEvent event) {
+        Long newsItemId = getSelectedNewsItemPlacement().getNewsItem().getId();
+        Long editionId = getSelectedNewsItemPlacement().getEdition().getId();
+        List<NewsItemActionState> properties = newsItemFacade.findNewsItemActionStates(editionId, newsItemId);
+        newsItemActionStates = new ListDataModel(properties);
+    }
+
+    public void onDeleteNewsItemActionStates(ActionEvent event) {
+        Long newsItemId = getSelectedNewsItemPlacement().getNewsItem().getId();
+        Long editionId = getSelectedNewsItemPlacement().getEdition().getId();
+        LOG.log(Level.FINE, "Clearing NewsItemActionState for Edition #{0} NewsItemId #{1}", new Object[]{editionId, newsItemId});
+        newsItemFacade.clearNewsItemActionState(editionId, newsItemId);
+        onRefreshNewsItemActionState(event);
+    }
+
+    public void onDeleteAllNewsItemActionState(ActionEvent event) {
+        Long editionId = getSelectedEditionView().getId();
+        newsItemFacade.clearNewsItemActionState(editionId);
+        onRefreshActionStates(event);
     }
 }

--- a/modules/converge-war/src/main/resources/dk/i2m/converge/i18n/WebUI.properties
+++ b/modules/converge-war/src/main/resources/dk/i2m/converge/i18n/WebUI.properties
@@ -11,28 +11,28 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with this program.  If not, see 
+# along with this program.  If not, see
 # <http://www.gnu.org/licenses/>.
 
 #
 # The format of labels is as follows:
 #
 #  Package underscore PageFileName underscore LABEL or
-#  Component underscore LABEL e.g.  
-#  The label page title on MyActivity.jspx 
+#  Component underscore LABEL e.g.
+#  The label page title on MyActivity.jspx
 #  is called MyActivity_PAGE_TITLE
 #            |         | |
 #            |         | |-- Label in upper case
 #            |         |---- Underscore
-#            |-------------- Filename (without extension) in 
+#            |-------------- Filename (without extension) in
 #                            capitalised camel case
 #
-#  The label page title on administrator/Outlets.jspx 
+#  The label page title on administrator/Outlets.jspx
 #  is called administrator_Outlets_PAGE_TITLE
 #            |            | |     | |
 #            |            | |     | |-- Label in upper case
 #            |            | |     |---- Underscore
-#            |            | |---- Filename (without extension) in 
+#            |            | |---- Filename (without extension) in
 #            |            |       capitalised camel case
 #            |            |---- Underscore
 #            |-------------- Package / directory name in camel case
@@ -327,6 +327,10 @@ Editions_EDITION_DETAILS_TAB_STATES=States
 Editions_EDITION_DETAILS_TAB_STATES_CLEAR_STATES=Clear States
 Editions_EDITION_DETAILS_TAB_STATES_CLEAR_STATES_CONFIRM=Are you sure that you want to clear all states for this edition?
 Editions_EDITION_DETAILS_TAB_STATES_CLEAR_STATES_TOOLTIP=Click to clear all the states for news items in this edition
+Editions_EDITION_DETAILS_TAB_ACTION_STATE=Action States
+Editions_EDITION_DETAILS_TAB_ACTION_STATE_CLEAR_STATES=Delete Action States
+Editions_EDITION_DETAILS_TAB_ACTION_STATE_CLEAR_STATES_CONFIRM=Are you sure that you want to clear all action states for this edition?
+Editions_EDITION_DETAILS_TAB_ACTION_STATE_CLEAR_STATES_TOOLTIP=Click to clear all the action states for news items in this edition
 Editions_EDITION_PROMPT_DELETE=Are you sure that you want to delete this edition? All sections and assignments for this edition will be deleted.
 Editions_EDITION_PROPERTIES=Edition Properties
 Editions_EDITION_PROPERTIES_TOOLTIP=Click to view the properties of the edition
@@ -378,6 +382,11 @@ Editions_NEWS_ITEM_PLACEMENT_DETAILS_TAB_STATE=State
 Editions_NEWS_ITEM_PLACEMENT_DETAILS_TAB_STATE_CLEAR_STATES=Delete States
 Editions_NEWS_ITEM_PLACEMENT_DETAILS_TAB_STATE_CLEAR_STATES_CONFIRM=Are you sure that you want to clear all the edition states for this news item?
 Editions_NEWS_ITEM_PLACEMENT_DETAILS_TAB_STATE_CLEAR_STATES_TOOLTIP=Click to clear the states of this news item for this edition
+Editions_NEWS_ITEM_PLACEMENT_DETAILS_TAB_ACTION_STATE=Action States
+Editions_NEWS_ITEM_PLACEMENT_DETAILS_TAB_ACTION_STATE_CLEAR_STATES=Delete Action States
+Editions_NEWS_ITEM_PLACEMENT_DETAILS_TAB_ACTION_STATE_CLEAR_STATES_CONFIRM=Are you sure that you want to clear all the action states for this news item?
+Editions_NEWS_ITEM_PLACEMENT_DETAILS_TAB_ACTION_STATE_CLEAR_STATES_TOOLTIP=Click to clear the action states of this news item for this edition
+
 Editions_NEW_TOOLTIP=Create a new edition for the selected outlet and date
 Editions_OPEN=Open
 Editions_OUTLET=Outlet
@@ -556,7 +565,7 @@ Inbox_DEADLINE=Deadline
 Inbox_DEADLINE_TOOLTIP=Deadline for the journalist to pass on the story
 Inbox_DUPLICATE=Duplicate
 Inbox_EMPTY_TRASH=Empty Trash
-Inbox_FILTER=Filter: 
+Inbox_FILTER=Filter:
 Inbox_INBOX_X=Inbox - {0}
 Inbox_ITEM_LOCKED=This item was checked-out by {0} at {1, date, h:mm a} on {1, date, d. MMMM}
 Inbox_ITEM_TRASHED=#{0} {1} was trashed
@@ -1350,9 +1359,9 @@ Search_CONTENT_TYPE_MEDIA=Media Items
 Search_CONTENT_TYPE_STORY=Stories
 Search_COULD_NOT_GENERATE_OVERVIEW_REPORT=Could not generate report. {0}
 Search_CRITERIA=Criteria
-Search_CRITERIA_DATE_FROM=Date from 
-Search_CRITERIA_DATE_TO= to 
-Search_CRITERIA_TYPE=Type of content: 
+Search_CRITERIA_DATE_FROM=Date from
+Search_CRITERIA_DATE_TO= to
+Search_CRITERIA_TYPE=Type of content:
 Search_DATE=Date
 Search_DATE_UNKNOWN=Unknown
 Search_DOWNLOAD_RESULTS_AS_SPREADSHEET=Download as spreadsheet
@@ -1375,7 +1384,7 @@ Search_SEARCH_BUTTON=Search
 Search_SEARCH_RESULTS=Search Results
 Search_SHOW=Show
 Search_SHOWING=Showing {1, choice, 0#results|1#result|2#results} {0} to {1}
-Search_SORT_BY=Sort by 
+Search_SORT_BY=Sort by
 Search_SORT_BY_DATE=Date
 Search_SORT_BY_SCORE=Score
 Search_SORT_ORDER_ASCENDING=Ascending
@@ -1606,7 +1615,7 @@ administrator_UserConfiguration_LDAP_GROUP_USERS=User group:
 administrator_UserConfiguration_LDAP_PROVIDER_URL=LDAP URL:
 administrator_UserConfiguration_LDAP_READ_TIMEOUT=Query/Read Timeout (ms):
 administrator_UserConfiguration_LDAP_SECURITY_AUTHENTICATION=Authentication Scheme:
-administrator_UserConfiguration_LDAP_SECURITY_CREDENTIALS=Security Credentials: 
+administrator_UserConfiguration_LDAP_SECURITY_CREDENTIALS=Security Credentials:
 administrator_UserConfiguration_LDAP_SECURITY_PRINCIPAL=Security Principle (dn):
 administrator_UserConfiguration_LDAP_SETTINGS=LDAP Settings
 administrator_UserConfiguration_LDAP_SETTINGS_HELP=Below you can configure the connection to your LDAP server and specify which groups contains the Converge users and administrators.
@@ -1641,7 +1650,7 @@ administrator_Workflows_PROCESS=Process
 administrator_Workflows_PROCESS_TIP=Every workflow must have a start and finish status
 administrator_Workflows_STATE=Workflow state
 administrator_Workflows_STATE_ACTOR=Actor
-administrator_Workflows_STATE_ACTOR_TOOLTIP=The actor of workflow 
+administrator_Workflows_STATE_ACTOR_TOOLTIP=The actor of workflow
 administrator_Workflows_STATE_DESCRIPTION=Description
 administrator_Workflows_STATE_DESCRIPTION_TOOLTIP=A description of the state. This description is shown to users when they inquire information about this state of their news items
 administrator_Workflows_STATE_DETAILS=Workflow state details
@@ -1667,7 +1676,7 @@ administrator_Workflows_STATE_OPTION_DISPLAY_ORDER_TOOLTIP=In which order should
 administrator_Workflows_STATE_OPTION_ID=ID
 administrator_Workflows_STATE_OPTION_ID_TOOLTIP=Unique identifier of the workflow state option
 administrator_Workflows_STATE_OPTION_NAME=Name
-administrator_Workflows_STATE_OPTION_NAME_REQUIRED=New Option is required 
+administrator_Workflows_STATE_OPTION_NAME_REQUIRED=New Option is required
 administrator_Workflows_STATE_OPTION_NAME_TOOLTIP=Option presented to the user at this state
 administrator_Workflows_STATE_OPTION_NEW=New option
 administrator_Workflows_STATE_OPTION_NEW_TOOLTIP=Create a new option for this state
@@ -1691,7 +1700,7 @@ administrator_Workflows_WORKFLOW_DESCRIPTION_TOOLTIP=Description of the workflow
 administrator_Workflows_WORKFLOW_DETAILS=Workflow details
 administrator_Workflows_WORKFLOW_ID=ID
 administrator_Workflows_WORKFLOW_ID_TOOLTIP=Identifier of the workflow
-administrator_Workflows_WORKFLOW_NAME=Name 
+administrator_Workflows_WORKFLOW_NAME=Name
 administrator_Workflows_WORKFLOW_NAME_REQUIRED=The name of the workflow is required
 administrator_Workflows_WORKFLOW_NAME_TOOLTIP=Name of the workflow
 administrator_Workflows_WORKFLOW_NEW=New Workflow

--- a/modules/converge-war/src/main/webapp/Editions.jspx
+++ b/modules/converge-war/src/main/webapp/Editions.jspx
@@ -42,7 +42,7 @@
                     <converge:moduleHeader moduleTitle="#{planning.editionTitle}" />
                     <div class="moduleContent">
                         <a4j:repeat value="#{planning.selectedEditions}" var="edition">
-                            
+
                             <div style="clear: both; padding-bottom: 12px;"></div>
 
                             <h:panelGrid columns="2" columnClasses="left, right" style="width: 100%">
@@ -51,7 +51,7 @@
                                         <f:param value="#{planning.selectedOutlet.title}" />
                                         <f:param value="#{edition.publicationDate}"/>
                                     </h:outputFormat>
-                                    
+
                                     <h:outputFormat value="#{i18n.Editions_EDITION_TITLE_CLOSED}" styleClass="editions_edition_title_closed" rendered="#{!edition.open}">
                                         <f:param value="#{planning.selectedOutlet.title}" />
                                         <f:param value="#{edition.publicationDate}"/>
@@ -73,7 +73,7 @@
 
                                 <rich:column styleClass="columnIcon center #{assignment.styleFg} bg-#{assignment.style}" headerClass="subColumnIcon">
                                     <f:facet name="header">
-                                        <a4j:commandLink ajaxSingle="true" reRender="dtEditionAssignments" actionListener="#{planning.onRefreshEditionPlacements}">  
+                                        <a4j:commandLink ajaxSingle="true" reRender="dtEditionAssignments" actionListener="#{planning.onRefreshEditionPlacements}">
                                             <h:graphicImage value="#{i18n.resource_ICON_REFRESH}" />
                                         </a4j:commandLink>
                                     </f:facet>
@@ -281,7 +281,7 @@
 
                                 <rich:tab id="tabState" label="#{i18n.Editions_EDITION_DETAILS_TAB_STATES}">
                                     <h:panelGrid columnClasses="tabSheet" style="padding: 10px; width: 100%">
-                                        <h:panelGroup layout="block" class="logEntryList"> 
+                                        <h:panelGroup layout="block" class="logEntryList">
 
                                             <h:panelGrid columns="2" columnClasses="left, right" style="width: 100%">
                                                 <h:outputText value="" />
@@ -292,7 +292,7 @@
                                             <rich:dataTable id="dtAllEditionStates" value="#{planning.editionStates}" var="state" styleClass="table" headerClass="tableHeader" rowClasses="odd, even">
                                                 <rich:column styleClass="columnIcon center" headerClass="columnIconHeader">
                                                     <f:facet name="header">
-                                                        <a4j:commandLink ajaxSingle="true" reRender="dtAllEditionStates" actionListener="#{planning.onRefreshEditionStates}">  
+                                                        <a4j:commandLink ajaxSingle="true" reRender="dtAllEditionStates" actionListener="#{planning.onRefreshEditionStates}">
                                                             <h:graphicImage value="#{i18n.resource_ICON_REFRESH}" />
                                                         </a4j:commandLink>
                                                     </f:facet>
@@ -323,11 +323,63 @@
                                         </h:panelGroup>
                                         <rich:spacer width="900" height="1" />
                                     </h:panelGrid>
-                                </rich:tab>                                                    
+                                </rich:tab>
+
+                                <rich:tab id="tabActionState" label="#{i18n.Editions_EDITION_DETAILS_TAB_ACTION_STATE}">
+                                    <h:panelGrid columnClasses="tabSheet" style="padding: 10px; width: 100%">
+                                        <h:panelGroup layout="block" class="logEntryList">
+                                            <h:panelGrid columns="2" columnClasses="left, right" style="width: 100%">
+                                                <h:outputText value="" />
+                                                <a4j:commandButton id="btnClearAllActionStates" styleClass="button dynamicButton" value="#{i18n.Editions_EDITION_DETAILS_TAB_ACTION_STATE_CLEAR_STATES}" title="#{i18n.Editions_EDITION_DETAILS_TAB_ACTION_STATE_CLEAR_STATES_TOOLTIP}" actionListener="#{planning.onDeleteAllNewsItemActionState}" reRender="dtAllActionStates" ajaxSingle="true" onclick="if (confirm('#{i18n.Editions_EDITION_DETAILS_TAB_ACTION_STATE_CLEAR_STATES_CONFIRM}') != true){ return false; };">
+                                                </a4j:commandButton>
+                                            </h:panelGrid>
+
+                                            <rich:dataTable id="dtAllActionStates" value="#{planning.actionStates}" var="state" styleClass="table" headerClass="tableHeader" rowClasses="odd, even">
+                                                <rich:column styleClass="columnIcon center" headerClass="columnIconHeader">
+                                                    <f:facet name="header">
+                                                        <a4j:commandLink ajaxSingle="true" reRender="dtAllActionStates" actionListener="#{planning.onRefreshActionStates}">
+                                                            <h:graphicImage value="#{i18n.resource_ICON_REFRESH}" />
+                                                        </a4j:commandLink>
+                                                    </f:facet>
+                                                    <h:graphicImage value="#{i18n.resource_ICON_LOG_ENTRY}" />
+                                                </rich:column>
+
+                                                <rich:column styleClass="" headerClass="">
+                                                    <f:facet name="header">
+                                                        <h:outputText value="News Item" />
+                                                    </f:facet>
+                                                    <h:outputText value="#{state.newsItem.id}" title="#{state.newsItem.title}" />
+                                                </rich:column>
+
+                                                <rich:column styleClass="" headerClass="">
+                                                    <f:facet name="header">
+                                                        <h:outputText value="Action" />
+                                                    </f:facet>
+                                                    <h:outputText value="#{state.action}" />
+                                                </rich:column>
+
+                                                <rich:column styleClass="" headerClass="">
+                                                    <f:facet name="header">
+                                                        <h:outputText value="State" />
+                                                    </f:facet>
+                                                    <h:outputText value="#{state.state}" />
+                                                </rich:column>
+
+                                                <rich:column styleClass="" headerClass="">
+                                                    <f:facet name="header">
+                                                        <h:outputText value="Data" />
+                                                    </f:facet>
+                                                    <h:outputText value="#{state.data}" />
+                                                </rich:column>
+                                            </rich:dataTable>
+                                        </h:panelGroup>
+                                        <rich:spacer width="900" height="1" />
+                                    </h:panelGrid>
+                                </rich:tab>
 
                                 <rich:tab id="tabEditionLog" label="#{i18n.Editions_EDITION_DETAILS_TAB_LOG}">
                                     <h:panelGrid columnClasses="tabSheet" style="padding: 10px; width: 100%">
-                                        <h:panelGroup layout="block" class="logEntryList"> 
+                                        <h:panelGroup layout="block" class="logEntryList">
 
                                             <h:panelGrid columns="2" columnClasses="left, right" style="width: 100%">
                                                 <h:outputText value="" />
@@ -339,7 +391,7 @@
                                             <rich:dataTable id="dtEditionLogEntries" value="#{planning.editionLogEntries}" var="logEntry" styleClass="table" headerClass="tableHeader" rowClasses="odd, even">
                                                 <rich:column styleClass="columnIcon center" headerClass="columnIconHeader">
                                                     <f:facet name="header">
-                                                        <a4j:commandLink ajaxSingle="true" reRender="dtEditionLogEntries" actionListener="#{planning.onRefreshEditionLogEntries}">  
+                                                        <a4j:commandLink ajaxSingle="true" reRender="dtEditionLogEntries" actionListener="#{planning.onRefreshEditionLogEntries}">
                                                             <h:graphicImage value="#{i18n.resource_ICON_REFRESH}" />
                                                         </a4j:commandLink>
                                                     </f:facet>
@@ -373,7 +425,7 @@
                                         </h:panelGroup>
                                         <rich:spacer width="900" height="1" />
                                     </h:panelGrid>
-                                </rich:tab>                                                
+                                </rich:tab>
 
                             </rich:tabPanel>
 
@@ -477,14 +529,14 @@
                                             <f:param name="content_css" value="css/wysiwyg.css" />
                                             <f:param name="gecko_spellcheck" value="true" />
                                             <f:param name="theme_advanced_path" value="false" />
-                                        </rich:editor>                                        
+                                        </rich:editor>
                                     </h:panelGrid>
                                 </rich:tab>
 
                                 <rich:tab id="tabActions" label="#{i18n.Editions_NEWS_ITEM_PLACEMENT_DETAILS_TAB_ACTIONS}">
                                     <h:panelGrid columnClasses="tabSheet" style="padding: 10px; width: 100%">
 
-                                        <h:panelGroup layout="block" class="actionList"> 
+                                        <h:panelGroup layout="block" class="actionList">
                                             <rich:dataTable id="dtActions" value="#{planning.selectedPlacementActions}" var="action" styleClass="table" headerClass="tableHeader" rowClasses="odd, even">
 
                                                 <rich:column styleClass="columnIcon center">
@@ -535,7 +587,7 @@
 
                                 <rich:tab id="tabState" label="#{i18n.Editions_NEWS_ITEM_PLACEMENT_DETAILS_TAB_STATE}">
                                     <h:panelGrid columnClasses="tabSheet" style="padding: 10px; width: 100%">
-                                        <h:panelGroup layout="block" class="logEntryList"> 
+                                        <h:panelGroup layout="block" class="logEntryList">
 
                                             <h:panelGrid columns="2" columnClasses="left, right" style="width: 100%">
                                                 <h:outputText value="" />
@@ -546,7 +598,7 @@
                                             <rich:dataTable id="dtNewsItemEditionStates" value="#{planning.newsItemEditionStates}" var="state" styleClass="table" headerClass="tableHeader" rowClasses="odd, even">
                                                 <rich:column styleClass="columnIcon center" headerClass="columnIconHeader">
                                                     <f:facet name="header">
-                                                        <a4j:commandLink ajaxSingle="true" reRender="dtNewsItemEditionStates" actionListener="#{planning.onRefreshNewsItemEditionState}">  
+                                                        <a4j:commandLink ajaxSingle="true" reRender="dtNewsItemEditionStates" actionListener="#{planning.onRefreshNewsItemEditionState}">
                                                             <h:graphicImage value="#{i18n.resource_ICON_REFRESH}" />
                                                         </a4j:commandLink>
                                                     </f:facet>
@@ -570,11 +622,56 @@
                                         </h:panelGroup>
                                         <rich:spacer width="900" height="1" />
                                     </h:panelGrid>
-                                </rich:tab>                                                    
+                                </rich:tab>
+
+                                <rich:tab id="tabActionState" label="#{i18n.Editions_NEWS_ITEM_PLACEMENT_DETAILS_TAB_ACTION_STATE}">
+                                    <h:panelGrid columnClasses="tabSheet" style="padding: 10px; width: 100%">
+                                        <h:panelGroup layout="block" class="logEntryList">
+                                            <h:panelGrid columns="2" columnClasses="left, right" style="width: 100%">
+                                                <h:outputText value="" />
+                                                <a4j:commandButton id="btnClearActionStates" styleClass="button dynamicButton" value="#{i18n.Editions_NEWS_ITEM_PLACEMENT_DETAILS_TAB_ACTION_STATE_CLEAR_STATES}" title="#{i18n.Editions_NEWS_ITEM_PLACEMENT_DETAILS_TAB_ACTION_STATE_CLEAR_STATES_TOOLTIP}" actionListener="#{planning.onDeleteNewsItemActionStates}" reRender="dtNewsItemActionStates" ajaxSingle="true" onclick="if (confirm('#{i18n.Editions_NEWS_ITEM_PLACEMENT_DETAILS_TAB_ACTION_STATE_CLEAR_STATES_CONFIRM}') != true){ return false; };">
+                                                </a4j:commandButton>
+                                            </h:panelGrid>
+
+                                            <rich:dataTable id="dtNewsItemActionStates" value="#{planning.newsItemActionStates}" var="state" styleClass="table" headerClass="tableHeader" rowClasses="odd, even">
+                                                <rich:column styleClass="columnIcon center" headerClass="columnIconHeader">
+                                                    <f:facet name="header">
+                                                        <a4j:commandLink ajaxSingle="true" reRender="dtNewsItemActionStates" actionListener="#{planning.onRefreshNewsItemActionState}">
+                                                            <h:graphicImage value="#{i18n.resource_ICON_REFRESH}" />
+                                                        </a4j:commandLink>
+                                                    </f:facet>
+                                                    <h:graphicImage value="#{i18n.resource_ICON_LOG_ENTRY}" />
+                                                </rich:column>
+
+                                                <rich:column styleClass="" headerClass="">
+                                                    <f:facet name="header">
+                                                        <h:outputText value="Action" />
+                                                    </f:facet>
+                                                    <h:outputText value="#{state.action}" />
+                                                </rich:column>
+
+                                                <rich:column styleClass="" headerClass="">
+                                                    <f:facet name="header">
+                                                        <h:outputText value="State" />
+                                                    </f:facet>
+                                                    <h:outputText value="#{state.state}" />
+                                                </rich:column>
+
+                                                <rich:column styleClass="" headerClass="">
+                                                    <f:facet name="header">
+                                                        <h:outputText value="Data" />
+                                                    </f:facet>
+                                                    <h:outputText value="#{state.data}" />
+                                                </rich:column>
+                                            </rich:dataTable>
+                                        </h:panelGroup>
+                                        <rich:spacer width="900" height="1" />
+                                    </h:panelGrid>
+                                </rich:tab>
 
                                 <rich:tab id="tabLog" label="#{i18n.Editions_NEWS_ITEM_PLACEMENT_DETAILS_TAB_LOG}">
                                     <h:panelGrid columnClasses="tabSheet" style="padding: 10px; width: 100%">
-                                        <h:panelGroup layout="block" class="logEntryList"> 
+                                        <h:panelGroup layout="block" class="logEntryList">
 
                                             <h:panelGrid columns="2" columnClasses="left, right" style="width: 100%">
                                                 <h:outputText value="" />
@@ -585,7 +682,7 @@
                                             <rich:dataTable id="dtLogEntries" value="#{planning.logEntries}" var="logEntry" styleClass="table" headerClass="tableHeader" rowClasses="odd, even">
                                                 <rich:column styleClass="columnIcon center" headerClass="columnIconHeader">
                                                     <f:facet name="header">
-                                                        <a4j:commandLink ajaxSingle="true" reRender="dtLogEntries" actionListener="#{planning.onRefreshNewsItemLogEntries}">  
+                                                        <a4j:commandLink ajaxSingle="true" reRender="dtLogEntries" actionListener="#{planning.onRefreshNewsItemLogEntries}">
                                                             <h:graphicImage value="#{i18n.resource_ICON_REFRESH}" />
                                                         </a4j:commandLink>
                                                     </f:facet>


### PR DESCRIPTION
`EditionAction` state entity to (eventually) replace `NewsItemEditionState`. `NewsItemEditionState` uses multiple (db) rows to store each state, and features no simple way of filtering by `EditionAction`. It's a tricky entity to use across multiple plugins. 

`NewsItemEditionState` example:

```
mysql> select * from news_item_edition_state where nid=1193148;
+---------+--------+---------+-------+----------+----------------------------------------+---------+
| id      | eid    | nid     | label | property | value                                  | visible |
+---------+--------+---------+-------+----------+----------------------------------------+---------+
| 1491282 | 482054 | 1193148 |       | status   | UPLOADED                               |       0 |
| 1491283 | 482054 | 1193148 |       | nid      | 39790                                  |       0 |
| 1491284 | 482054 | 1193148 |       | uri      | http://example.com/converge/node/39790 |       0 |
| 1491285 | 482054 | 1193148 |       | path     | http://example.com/news/hello-world    |       0 |
| 1491286 | 482054 | 1193148 |       | version  | 1440571352000                          |       0 |
| 1491287 | 482054 | 1193148 |       | date     | Wed Aug 26 10:26:05 EAT 2015           |       0 |
+---------+--------+---------+-------+----------+----------------------------------------+---------+
```

`NewsItemActionState` stores the (plugin) class that owns the state. Custom data goes under a single field. 

`NewsItemActionState` example:

```
mysql> select * from news_item_action_state where news_item_id=1193148;
+--------+---------------------------------------+----------+----------------------------------------------------+------------+--------------+
| id     | data                                  | state    | edition_action                                     | edition_id | news_item_id |
+--------+---------------------------------------+----------+----------------------------------------------------+------------+--------------+
| 103982 | {"nid":39790,"version":1440571352000} | UPLOADED | dk.i2m.converge.plugins.drupal.DrupalEditionAction |     482054 |      1193148 |
+--------+---------------------------------------+----------+----------------------------------------------------+------------+--------------+
```
