### PR TITLE
Order log entries by id rather than date

### DIFF
--- a/modules/converge-core/src/main/java/dk/i2m/converge/core/logging/LogEntry.java
+++ b/modules/converge-core/src/main/java/dk/i2m/converge/core/logging/LogEntry.java
@@ -33,7 +33,7 @@ import org.eclipse.persistence.annotations.PrivateOwned;
 @Entity
 @Table(name = "log_entry")
 @NamedQueries({
-    @NamedQuery(name = LogEntry.FIND_BY_ENTITY, query = "SELECT l FROM LogEntry l JOIN l.subjects s WHERE s.entity = :" + LogEntry.PARAMETER_ENTITY + " AND s.entityId = :" + LogEntry.PARAMETER_ENTITY_ID + " ORDER BY l.date DESC"),
+    @NamedQuery(name = LogEntry.FIND_BY_ENTITY, query = "SELECT l FROM LogEntry l JOIN l.subjects s WHERE s.entity = :" + LogEntry.PARAMETER_ENTITY + " AND s.entityId = :" + LogEntry.PARAMETER_ENTITY_ID + " ORDER BY l.id DESC"),
 
     // Would like to implement an effecient way of deleting LogEntries, but the 
     // below query is translated to the below SQL statement and fails with 


### PR DESCRIPTION
Entries that share dates (to the second) will get randomly ordered. Sorting by id, will ensure order is retained.
